### PR TITLE
A couple of fixes/tweaks

### DIFF
--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -107,7 +107,12 @@ class TftpServer(TftpSession):
                                                                timeout,
                                                                self.root,
                                                                self.dyn_file_func)
-                        self.sessions[key].start(buffer)
+                        try:
+                            self.sessions[key].start(buffer)
+                        except TftpException, err:
+                            deletion_list.append(key)
+                            log.error("Fatal exception thrown from "
+                                      "session %s: %s" % (key, str(err)))
                     else:
                         log.warn("received traffic on main socket for "
                                  "existing session??")

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -115,7 +115,7 @@ class TftpContext(object):
         called explicitely by the calling code, this works better than the
         destructor."""
         log.debug("in TftpContext.end")
-        if not self.fileobj.closed:
+        if self.fileobj is not None and not self.fileobj.closed:
             log.debug("self.fileobj is open - closing")
             self.fileobj.close()
 


### PR DESCRIPTION
Hi,

No idea if these changes fit into your architectural plan for tftpy (so I'm happy to refactor them) but they're useful for me:-
- Allow dyn_file_func to return None to cause a FileNotFound error to be sent to the client.
- Prevent a TftpException during .start() from exiting out of the entire loop in .listen().
