### PR TITLE
Compatibility with Python 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,16 @@
 
 from distutils.core import setup
 
+try:
+    from distutils.command.build_py import build_py_2to3 as build_py
+except ImportError:
+    from distutils.command.build_py import build_py
+
+try:
+    from distutils.command.build_scripts import build_scripts_2to3 as build_scripts
+except ImportError:
+    from distutils.command.build_scripts import build_scripts
+
 setup(name='tftpy',
       version='0.6.1',
       description='Python TFTP library',
@@ -10,6 +20,7 @@ setup(name='tftpy',
       url='http://tftpy.sourceforge.net',
       packages=['tftpy'],
       scripts=['bin/tftpy_client.py','bin/tftpy_server.py'],
+      cmdclass = {'build_py': build_py, 'build_scripts':build_scripts},
       classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/t/test.py
+++ b/t/test.py
@@ -5,6 +5,7 @@ import logging
 import tftpy
 import os
 import time
+import sys
 
 log = tftpy.log
 
@@ -68,7 +69,10 @@ class TestTftpyClasses(unittest.TestCase):
         log.debug("===> Running testcase testTftpPacketDAT")
         dat = tftpy.TftpPacketDAT()
         dat.blocknumber = 5
-        data = "this is some data"
+        if sys.version < '3':
+            data = "this is some data"
+        else:
+            data = b"this is some data"
         dat.data = data
         dat.encode()
         self.assert_(dat.buffer != None, "Buffer populated")
@@ -196,7 +200,10 @@ class TestTftpyState(unittest.TestCase):
         self.clientServerDownloadOptions({})
 
     def testClientFileObject(self):
-        output = open('/tmp/out', 'w')
+        if sys.version < '3':
+            output = open('/tmp/out', 'w')
+        else:
+            output = open('/tmp/out', 'wb')
         self.clientServerDownloadOptions({}, output)
 
     def testClientServerBlksize(self):
@@ -207,7 +214,10 @@ class TestTftpyState(unittest.TestCase):
         self.clientServerUploadOptions({})
 
     def testClientServerUploadFileObj(self):
-        fileobj = open('t/640KBFILE', 'r')
+        if sys.version < '3':
+            fileobj = open('t/640KBFILE', 'r')
+        else:
+            fileobj = open('t/640KBFILE', 'rb')
         self.clientServerUploadOptions({}, input=fileobj)
 
     def testClientServerUploadWithSubdirs(self):
@@ -371,7 +381,7 @@ class TestTftpyState(unittest.TestCase):
             signal.alarm(2)
             try:
                 server.listen('localhost', 20001)
-            except Exception, err:
+            except Exception as err:
                 self.assertTrue( err[0] == 4 )
 
     def testServerDownloadWithStopNotNow(self, output='/tmp/out'):
@@ -408,7 +418,7 @@ class TestTftpyState(unittest.TestCase):
             signal.alarm(2)
             try:
                 server.listen('localhost', 20001)
-            except Exception, err:
+            except Exception:
                 self.assertTrue( False, "Server should not exit early" )
 
 if __name__ == '__main__':

--- a/t/test.py
+++ b/t/test.py
@@ -28,7 +28,7 @@ class TestTftpyClasses(unittest.TestCase):
         self.assertEqual(rrq.mode, "octet", "Mode correct")
         self.assertEqual(rrq.options, options, "Options correct")
         # repeat test with options
-        rrq.options = { 'blksize': '1024' }
+        rrq.options = { 'blksize': 1024 }
         rrq.filename = 'myfilename'
         rrq.mode = 'octet'
         rrq.encode()
@@ -36,7 +36,7 @@ class TestTftpyClasses(unittest.TestCase):
         rrq.decode()
         self.assertEqual(rrq.filename, "myfilename", "Filename correct")
         self.assertEqual(rrq.mode, "octet", "Mode correct")
-        self.assertEqual(rrq.options['blksize'], '1024', "Blksize correct")
+        self.assertEqual(rrq.options['blksize'], 1024, "Blksize correct")
 
     def testTftpPacketWRQ(self):
         log.debug("===> Running test case testTftpPacketWRQ")
@@ -53,7 +53,7 @@ class TestTftpyClasses(unittest.TestCase):
         self.assertEqual(wrq.mode, "octet", "Mode correct")
         self.assertEqual(wrq.options, options, "Options correct")
         # repeat test with options
-        wrq.options = { 'blksize': '1024' }
+        wrq.options = { 'blksize': 1024 }
         wrq.filename = 'myfilename'
         wrq.mode = 'octet'
         wrq.encode()
@@ -62,7 +62,7 @@ class TestTftpyClasses(unittest.TestCase):
         self.assertEqual(wrq.opcode, 2, "Opcode correct")
         self.assertEqual(wrq.filename, "myfilename", "Filename correct")
         self.assertEqual(wrq.mode, "octet", "Mode correct")
-        self.assertEqual(wrq.options['blksize'], '1024', "Blksize correct")
+        self.assertEqual(wrq.options['blksize'], 1024, "Blksize correct")
 
 
     def testTftpPacketDAT(self):
@@ -111,16 +111,16 @@ class TestTftpyClasses(unittest.TestCase):
         oack.decode()
         self.assertEqual(oack.opcode, 6, "OACK opcode is correct")
         self.assertEqual(oack.options['blksize'],
-                         '2048',
+                         2048,
                          "OACK blksize option is correct")
         # Test string to string
-        oack.options = { 'blksize': '4096' }
+        oack.options = { 'blksize': 4096 }
         oack.encode()
         self.assert_(oack.buffer != None, "Buffer populated")
         oack.decode()
         self.assertEqual(oack.opcode, 6, "OACK opcode is correct")
         self.assertEqual(oack.options['blksize'],
-                         '4096',
+                         4096,
                          "OACK blksize option is correct")
         
     def testTftpPacketFactory(self):

--- a/tftpy/TftpPacketTypes.py
+++ b/tftpy/TftpPacketTypes.py
@@ -187,8 +187,8 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
         mystruct = struct.unpack(format, shortbuf)
 
         tftpassert(len(mystruct) == 2, "malformed packet")
-        self.filename = mystruct[0]
-        self.mode = mystruct[1].lower() # force lc - bug 17
+        self.filename = s(mystruct[0])
+        self.mode = s(mystruct[1].lower()) # force lc - bug 17
         log.debug("set filename to %s", self.filename)
         log.debug("set mode to %s", self.mode)
 
@@ -413,8 +413,8 @@ class TftpPacketOACK(TftpPacket, TftpPacketWithOptions):
             log.debug("value is %s", self.options[key])
             format += "%dsx" % len(key)
             format += "%dsx" % len(self.options[key])
-            options_list.append(key)
-            options_list.append(self.options[key])
+            options_list.append(b(key))
+            options_list.append(b(self.options[key]))
         self.buffer = struct.pack(format, self.opcode, *options_list)
         return self
 

--- a/tftpy/TftpShared.py
+++ b/tftpy/TftpShared.py
@@ -22,34 +22,39 @@ logging.basicConfig()
 log = logging.getLogger('tftpy')
 
 if sys.version < '3':
-    def b(x):
-        if not isinstance(x, str):
-            x = str(x)
-        return x
-else:
-    import codecs
-    def b(x):
-        if not isinstance(x, bytes):
-            if not isinstance(x, str):
-                x = str(x)
-            return codecs.latin_1_encode(x)[0]
-        else:
+    def to_bytes(x):
+        if isinstance(x, str):
             return x
-
-if sys.version < '3':
-    def s(x):
-        if not isinstance(x, str):
-            x = str(x)
-        return x
-else:
-    import codecs
-    def s(x):
-        if not isinstance(x, str):
-            if isinstance(x, bytes):
-                return codecs.latin_1_decode(x)[0]
+        elif isinstance(x, unicode):
+            return x.encode()
+        elif isinstance(x, int):
             return str(x)
         else:
+            return None
+else:
+    def to_bytes(x):
+        if isinstance(x, bytes):
             return x
+        elif isinstance(x, str):
+            return x.encode()
+        elif isinstance(x, int):
+            return str(x).encode()
+        else:
+            return None
+
+if sys.version < '3':
+    def to_str(x):
+        return to_bytes(x)
+else:
+    def to_str(x):
+        if isinstance(x, str):
+            return x
+        elif isinstance(x, bytes):
+            return x.decode()
+        elif isinstance(x, int):
+            return str(x)
+        else:
+            return None
 
 def tftpassert(condition, msg):
     """This function is a simple utility that will check the condition

--- a/tftpy/TftpShared.py
+++ b/tftpy/TftpShared.py
@@ -25,8 +25,6 @@ if sys.version < '3':
     def to_bytes(x):
         if isinstance(x, str):
             return x
-        elif isinstance(x, unicode):
-            return x.encode()
         elif isinstance(x, int):
             return str(x)
         else:

--- a/tftpy/TftpShared.py
+++ b/tftpy/TftpShared.py
@@ -1,6 +1,7 @@
 """This module holds all objects shared by all other modules in tftpy."""
 
 import logging
+import sys
 
 LOG_LEVEL = logging.NOTSET
 MIN_BLKSIZE = 8
@@ -19,6 +20,36 @@ logging.basicConfig()
 # The logger used by this library. Feel free to clobber it with your own, if you like, as
 # long as it conforms to Python's logging.
 log = logging.getLogger('tftpy')
+
+if sys.version < '3':
+    def b(x):
+        if not isinstance(x, str):
+            x = str(x)
+        return x
+else:
+    import codecs
+    def b(x):
+        if not isinstance(x, bytes):
+            if not isinstance(x, str):
+                x = str(x)
+            return codecs.latin_1_encode(x)[0]
+        else:
+            return x
+
+if sys.version < '3':
+    def s(x):
+        if not isinstance(x, str):
+            x = str(x)
+        return x
+else:
+    import codecs
+    def s(x):
+        if not isinstance(x, str):
+            if isinstance(x, bytes):
+                return codecs.latin_1_decode(x)[0]
+            return str(x)
+        else:
+            return x
 
 def tftpassert(condition, msg):
     """This function is a simple utility that will check the condition

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -33,7 +33,7 @@ class TftpState(object):
     def handleOACK(self, pkt):
         """This method handles an OACK from the server, syncing any accepted
         options."""
-        if pkt.options.keys() > 0:
+        if len(pkt.options) > 0:
             if pkt.match_options(self.context.options):
                 log.info("Successful negotiation of options")
                 # Set options to OACK options

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -39,7 +39,7 @@ class TftpState(object):
                 # Set options to OACK options
                 self.context.options = pkt.options
                 for key in self.context.options:
-                    log.info("    %s = %s" % (key, self.context.options[key]))
+                    log.info("    %s = %d" % (key, self.context.options[key]))
             else:
                 log.error("Failed to negotiate options")
                 raise TftpException, "Failed to negotiate options"
@@ -55,11 +55,11 @@ class TftpState(object):
         for option in options:
             if option == 'blksize':
                 # Make sure it's valid.
-                if int(options[option]) > MAX_BLKSIZE:
+                if options[option] > MAX_BLKSIZE:
                     log.info("Client requested blksize greater than %d "
                              "setting to maximum" % MAX_BLKSIZE)
                     accepted_options[option] = MAX_BLKSIZE
-                elif int(options[option]) < MIN_BLKSIZE:
+                elif options[option] < MIN_BLKSIZE:
                     log.info("Client requested blksize less than %d "
                              "setting to minimum" % MIN_BLKSIZE)
                     accepted_options[option] = MIN_BLKSIZE


### PR DESCRIPTION
What was changed:
1) Modified setup.py to call 2to3 script. This will automatically introduce lots of Python 3 improvements during setup procedure.
2) Created to_bytes() and to_str() functions that will handle string conversion. These functions differ for both version of Python.
3) Changed internal representation of options value to int instead of string. AFAIK all TFTP options values are right now integers so this should work without any issue. I wanted integers because it is easier to handle them than strings in Python 2 and 3. Additionally lots of options value calculations are done using integers so this simplify some part of code.
4) Updated unittests to work with Python 3
5) Few small changes that increase compatibility between Python 2 and 3.
