### PR TITLE
Added localip parameter for TFTPClient

### DIFF
--- a/tftpy/TftpClient.py
+++ b/tftpy/TftpClient.py
@@ -12,13 +12,14 @@ class TftpClient(TftpSession):
     download can be initiated via the download() method, or an upload via the
     upload() method."""
 
-    def __init__(self, host, port, options={}):
+    def __init__(self, host, port, options={}, localip = ""):
         TftpSession.__init__(self)
         self.context = None
         self.host = host
         self.iport = port
         self.filename = None
         self.options = options
+        self.localip = localip
         if self.options.has_key('blksize'):
             size = self.options['blksize']
             tftpassert(types.IntType == type(size), "blksize must be an int")
@@ -48,7 +49,8 @@ class TftpClient(TftpSession):
                                                  output,
                                                  self.options,
                                                  packethook,
-                                                 timeout)
+                                                 timeout,
+                                                 localip = self.localip)
         self.context.start()
         # Download happens here
         self.context.end()
@@ -82,7 +84,8 @@ class TftpClient(TftpSession):
                                                input,
                                                self.options,
                                                packethook,
-                                               timeout)
+                                               timeout,
+                                               localip = self.localip)
         self.context.start()
         # Upload happens here
         self.context.end()

--- a/tftpy/TftpContexts.py
+++ b/tftpy/TftpContexts.py
@@ -67,7 +67,7 @@ class TftpMetrics(object):
 class TftpContext(object):
     """The base class of the contexts."""
 
-    def __init__(self, host, port, timeout):
+    def __init__(self, host, port, timeout, localip = ""):
         """Constructor for the base context, setting shared instance
         variables."""
         self.file_to_transfer = None
@@ -75,6 +75,8 @@ class TftpContext(object):
         self.options = None
         self.packethook = None
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        if localip != "":
+            self.sock.bind((localip, 0))
         self.sock.settimeout(timeout)
         self.timeout = timeout
         self.state = None
@@ -247,11 +249,13 @@ class TftpContextClientUpload(TftpContext):
                  input,
                  options,
                  packethook,
-                 timeout):
+                 timeout,
+                 localip = ""):
         TftpContext.__init__(self,
                              host,
                              port,
-                             timeout)
+                             timeout,
+                             localip)
         self.file_to_transfer = filename
         self.options = options
         self.packethook = packethook
@@ -323,11 +327,13 @@ class TftpContextClientDownload(TftpContext):
                  output,
                  options,
                  packethook,
-                 timeout):
+                 timeout,
+                 localip = ""):
         TftpContext.__init__(self,
                              host,
                              port,
-                             timeout)
+                             timeout,
+                             localip)
         # FIXME: should we refactor setting of these params?
         self.file_to_transfer = filename
         self.options = options


### PR DESCRIPTION
Sometimes it is handy to have possibility to bind client to specific IP address/network interface to prevent ambiguity in routing.
This is useful very often if you have multiple network interfaces or multiple IP addressed assigned to one interface.