### PR TITLE
Add support for context-based files

### DIFF
--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -10,6 +10,7 @@ error, in which case a TftpException is returned instead."""
 
 from TftpShared import *
 from TftpPacketTypes import *
+import inspect
 import os
 
 ###############################################################################
@@ -302,11 +303,9 @@ class TftpStateServerRecvRRQ(TftpServerState):
             if len(args.args) == 1:
                 self.context.fileobj = \
                     self.context.dyn_file_func(self.context.file_to_transfer)
-            elif len(args.args) == 2:
+            elif len(args.args) >= 2:
                 self.context.fileobj = \
                     self.context.dyn_file_func(self.context.file_to_transfer, self.context)
-            else:
-                log.error("dyn_file_func takes %d parameters, but tftpy can only handle 1 or 2" % len(args.args))
 
             if self.context.fileobj is None:
                 log.debug("dyn_file_func returned 'None', treating as "

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -300,12 +300,12 @@ class TftpStateServerRecvRRQ(TftpServerState):
         elif self.context.dyn_file_func:
             log.debug("No such file %s but using dyn_file_func", path)
             args = inspect.getargs(self.context.dyn_file_func.__code__)
-            if len(args.args) == 1:
+            if 'context' in args.args:
+                self.context.fileobj = \
+                    self.context.dyn_file_func(self.context.file_to_transfer, context = self.context)
+            else:
                 self.context.fileobj = \
                     self.context.dyn_file_func(self.context.file_to_transfer)
-            elif len(args.args) >= 2:
-                self.context.fileobj = \
-                    self.context.dyn_file_func(self.context.file_to_transfer, self.context)
 
             if self.context.fileobj is None:
                 log.debug("dyn_file_func returned 'None', treating as "

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -298,8 +298,15 @@ class TftpStateServerRecvRRQ(TftpServerState):
             self.context.fileobj = open(path, "rb")
         elif self.context.dyn_file_func:
             log.debug("No such file %s but using dyn_file_func", path)
-            self.context.fileobj = \
-                self.context.dyn_file_func(self.context.file_to_transfer)
+            args = inspect.getargs(self.context.dyn_file_func.__code__)
+            if len(args.args) == 1:
+                self.context.fileobj = \
+                    self.context.dyn_file_func(self.context.file_to_transfer)
+            elif len(args.args) == 2:
+                self.context.fileobj = \
+                    self.context.dyn_file_func(self.context.file_to_transfer, self.context)
+            else:
+                log.error("dyn_file_func takes %d parameters, but tftpy can only handle 1 or 2" % len(args.args))
 
             if self.context.fileobj is None:
                 log.debug("dyn_file_func returned 'None', treating as "


### PR DESCRIPTION
Cisco routers, by default, ask for various filenames.  None of them, however, contain the MAC of the device in question.  Therefore, bootstrapping Cisco devices by using dynamic files seems a good idea, but is hard to do because the dynamic file handler doesn't get anything more than a filename.

In order to overcome this, I propose optionally passing the "context" parameter to the dynamic file function.  This allows the use of details such as IP, MAC, etc to determine which file to load.

This set of patches adds this functionality, while (I believe) maintaining backwards compatibility for functions taking one parameter.
