### PR TITLE
Adjust ACK handling to truncate too long packets.

### DIFF
--- a/tftpy/TftpPacketTypes.py
+++ b/tftpy/TftpPacketTypes.py
@@ -305,6 +305,10 @@ class TftpPacketACK(TftpPacket):
         return self
 
     def decode(self):
+        if len(self.buffer) > 4:
+            log.debug("detected TFTP ACK but request is too large, will truncate")
+            log.debug("buffer was: %s", repr(self.buffer))
+            self.buffer = self.buffer[0:4]
         self.opcode, self.blocknumber = struct.unpack("!HH", self.buffer)
         log.debug("decoded ACK packet: opcode = %d, block = %d",
                      self.opcode, self.blocknumber)


### PR DESCRIPTION
It appears (at least) a Dell PowerConnect 6248 will send ACK packets that are
29 bytes long.  The first 4 match the correct format (2b opcode, 2b block),
and it appears the rest of the message is padding with null bytes (at least
via some cursory debugging).

By default, tftpy will barf when this happens complaining it can't unpack 29
bytes with a format of "!HH".

This change will ignore anything not "in spec" for an ACK packet by truncating
the message to 4 bytes before continuing.

This causes tftpy to work fine for my PC6248 switch.