### PR TITLE
server: add -q option to supress liberal INFO level debugging

### DIFF
--- a/bin/tftpy_server.py
+++ b/bin/tftpy_server.py
@@ -22,6 +22,11 @@ def main():
                       type='string',
                       help='path to serve from',
                       default=None)
+    parser.add_option('-q',
+                      '--quiet',
+                      action='store_true',
+                      default=False,
+                      help="Do not log unless it is critical")
     parser.add_option('-d',
                       '--debug',
                       action='store_true',
@@ -31,6 +36,8 @@ def main():
 
     if options.debug:
         tftpy.setLogLevel(logging.DEBUG)
+    elif options.quiet:
+        tftpy.setLogLevel(logging.WARN)
     else:
         tftpy.setLogLevel(logging.INFO)
 


### PR DESCRIPTION
In my test from U-Boot tftp client to a server running on windows
this increase the transfer rate from 1.8MB/s to 4.9MB/s (nearly
3x performance improvement).

Signed-off-by: Paul Osborne <Paul.Osborne@digi.com>