### PR TITLE
Added resending of DAT following a duplicate ACK.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='tftpy',
-      version='0.6.2',
+      version='0.6.3    ',
       description='Python TFTP library',
       author='Michael P. Soulier',
       author_email='msoulier@digitaltorque.ca',

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -437,6 +437,8 @@ class TftpStateExpectACK(TftpState):
                 log.warn("Received duplicate ACK for block %d"
                     % pkt.blocknumber)
                 self.context.metrics.add_dup(pkt)
+                self.context.pending_complete = self.resendLast()
+
 
             else:
                 log.warn("Oooh, time warp. Received ACK to packet we "


### PR DESCRIPTION
Hi

I made a modification to tftpy. When duplicate ACKs are received by a client it usually is an indication that a DAT packet was missed by the server and it is ACK'in the previous DAT packet

The modification I made causes a DAT packet to be resent if a duplicate ACK is received

I'll admit I'm not an expert at either TFTP or your codebase but I have seen it fix an issue I saw with one proprietary tftp server implementation,

Diarmuid
