### PR TITLE
Dynamic uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tags
 .DS_Store
 test.log
+tftpy.egg-info

--- a/t/test.py
+++ b/t/test.py
@@ -234,7 +234,7 @@ class TestTftpyState(unittest.TestCase):
     def customUploadHelper(self, return_func):
         q = Queue()
 
-        def upload_open(path):
+        def upload_open(path, context):
             q.put('called')
             return return_func(path)
         self.clientServerUploadOptions(

--- a/tftpy/TftpContexts.py
+++ b/tftpy/TftpContexts.py
@@ -196,7 +196,13 @@ class TftpContext(object):
 
 class TftpContextServer(TftpContext):
     """The context for the server."""
-    def __init__(self, host, port, timeout, root, dyn_file_func=None):
+    def __init__(self,
+                 host,
+                 port,
+                 timeout,
+                 root,
+                 dyn_file_func=None,
+                 upload_open=None):
         TftpContext.__init__(self,
                              host,
                              port,
@@ -208,6 +214,7 @@ class TftpContextServer(TftpContext):
 
         self.root = root
         self.dyn_file_func = dyn_file_func
+        self.upload_open = upload_open
 
     def __str__(self):
         return "%s:%s %s" % (self.host, self.port, self.state)

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -16,9 +16,10 @@ class TftpServer(TftpSession):
     """This class implements a tftp server object. Run the listen() method to
     listen for client requests.  It takes two optional arguments. tftproot is
     the path to the tftproot directory to serve files from and/or write them
-    to. dyn_file_func is a callable that must return a file-like object to
-    read from during downloads. This permits the serving of dynamic
-    content."""
+    to. dyn_file_func is a callable that takes a requested download path that
+    is not present on the file system and must return either a file-like object
+    to read from or None if the path should appear as not found. This permits
+    the serving of dynamic content."""
 
     def __init__(self, tftproot='/tftpboot', dyn_file_func=None):
         self.listenip = None

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -25,8 +25,8 @@ class TftpServer(TftpSession):
     found. This permits the serving of dynamic content.
 
     upload_open is a callable that is triggered on every upload with the
-    requested destination path. It must either return a file-like
-    object ready for writing or None if the path is invalid."""
+    requested destination path and server context. It must either return a
+    file-like object ready for writing or None if the path is invalid."""
 
     def __init__(self,
                  tftproot='/tftpboot',

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -365,7 +365,7 @@ class TftpStateServerRecvWRQ(TftpServerState):
         sendoack = self.serverInitial(pkt, raddress, rport)
         path = self.full_path
         if self.context.upload_open:
-            f = self.context.upload_open(path)
+            f = self.context.upload_open(path, self.context)
             if f is None:
                 self.sendError(TftpErrors.AccessViolation)
                 raise TftpException, "Dynamic path %s not permitted" % path


### PR DESCRIPTION
One can supply a `TftpServer` with a `dyn_file_func` so that a client downloading a (non-existant) file can be served with dynamic content. We'd like to do something similar in reverse: have a hook that intercepts the opening of a new file on upload so that we can check some stuff before it gets written.

This pull request adds a new `upload_open` argument (happy for better suggestions on the name!), which, similar to `dyn_file_func` is a callable that is executed when dynamic upload is required. Unlike `dyn_file_func` it is not called conditionally - if the application code specifies dynamic file opening on upload, it is always in charge of opening files, and can return `None` to indicate an issue. (Here, I chose to raise a permission issue, rather than "File not found" because the latter seemed weird on an upload).