### PR TITLE
Fix python3 syntax issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-*.pyc
+*.py[cod]
 *.swp
 tags
 .DS_Store
 test.log
 tftpy.egg-info
+build/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*$py.class

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -53,8 +53,8 @@ class TftpServer(TftpSession):
         for name in 'dyn_file_func', 'upload_open':
             attr = getattr(self, name)
             if attr and not callable(attr):
-                raise TftpException, "%s supplied, but it is not callable." % (
-                    name,)
+                raise TftpException("%s supplied, but it is not callable." % (
+                    name,))
         if os.path.exists(self.root):
             log.debug("tftproot %s does exist", self.root)
             if not os.path.isdir(self.root):

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -368,7 +368,7 @@ class TftpStateServerRecvWRQ(TftpServerState):
             f = self.context.upload_open(path, self.context)
             if f is None:
                 self.sendError(TftpErrors.AccessViolation)
-                raise TftpException, "Dynamic path %s not permitted" % path
+                raise TftpException("Dynamic path %s not permitted" % path)
             else:
                 self.context.fileobj = f
         else:


### PR DESCRIPTION
Raise was still the old syntax at some part of the code. 

Traceback (most recent call last):                                                                                                                                                                                 
  File "<stdin>", line 1, in <module>                                                                                                                                                                              
  File "/home/tessares/Downloads/tftpy/tftpy/__init__.py", line 23, in <module>                                                                                                                                    
    from .TftpServer import *                                                                                                                                                                                      
  File "/home/tessares/Downloads/tftpy/tftpy/TftpServer.py", line 56                                                                                                                                               
    raise TftpException, "%s supplied, but it is not callable." % (                                                                                                                                                
                       ^                                                                                                                                                                                           
SyntaxError: invalid syntax