### PR TITLE
Fix encoding position in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# vim: ts=4 sw=4 et ai:
 # -*- coding: utf8 -*-
+# vim: ts=4 sw=4 et ai:
 
 from distutils.core import setup
 


### PR DESCRIPTION
Per PEP-0263 encoding needs to be on the first or second line, https://www.python.org/dev/peps/pep-0263/#defining-the-encoding.  This change moves the encoding to the second line which resolves this error:
./setup.py build
  File "./setup.py", line 47
SyntaxError: Non-ASCII character '\xc5' in file ./setup.py on line 48, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details