### PR TITLE
Accept None as TFTP root

### DIFF
--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -79,6 +79,9 @@ class TftpServer(TftpSession):
                         log.warning("The tftproot %s is not writable" % self.root)
             else:
                 raise TftpException("The tftproot does not exist.")
+        else:
+            if dyn_file_func == None:
+                raise TftpException("No tftproot and no dyn_file_func given")
 
     def listen(self, listenip="", listenport=DEF_TFTP_PORT,
                timeout=SOCK_TIMEOUT):

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -42,7 +42,10 @@ class TftpServer(TftpSession):
         self.listenport = None
         self.sock = None
         # FIXME: What about multiple roots?
-        self.root = os.path.abspath(tftproot)
+        if tftproot != None:
+            self.root = os.path.abspath(tftproot)
+        else:
+            self.root = None
         self.dyn_file_func = dyn_file_func
         self.upload_open = upload_open
         # A dict of sessions, where each session is keyed by a string like
@@ -59,22 +62,23 @@ class TftpServer(TftpSession):
             attr = getattr(self, name)
             if attr and not callable(attr):
                 raise TftpException("{} supplied, but it is not callable.".format(name))
-        if os.path.exists(self.root):
-            log.debug("tftproot %s does exist", self.root)
-            if not os.path.isdir(self.root):
-                raise TftpException("The tftproot must be a directory.")
+        if self.root != None:
+            if os.path.exists(self.root):
+                log.debug("tftproot %s does exist", self.root)
+                if not os.path.isdir(self.root):
+                    raise TftpException("The tftproot must be a directory.")
+                else:
+                    log.debug("tftproot %s is a directory" % self.root)
+                    if os.access(self.root, os.R_OK):
+                        log.debug("tftproot %s is readable" % self.root)
+                    else:
+                        raise TftpException("The tftproot must be readable")
+                    if os.access(self.root, os.W_OK):
+                        log.debug("tftproot %s is writable" % self.root)
+                    else:
+                        log.warning("The tftproot %s is not writable" % self.root)
             else:
-                log.debug("tftproot %s is a directory" % self.root)
-                if os.access(self.root, os.R_OK):
-                    log.debug("tftproot %s is readable" % self.root)
-                else:
-                    raise TftpException("The tftproot must be readable")
-                if os.access(self.root, os.W_OK):
-                    log.debug("tftproot %s is writable" % self.root)
-                else:
-                    log.warning("The tftproot %s is not writable" % self.root)
-        else:
-            raise TftpException("The tftproot does not exist.")
+                raise TftpException("The tftproot does not exist.")
 
     def listen(self, listenip="", listenport=DEF_TFTP_PORT,
                timeout=SOCK_TIMEOUT):


### PR DESCRIPTION
If None is given as tftproot upon tftpServer creation, the server always
forwards the file returned by its dyn_file_func method. This is useful if full
access to the file system should not be granted for the tftp client. The
client can still get files, but is restricted as appropriate by the
dyn_file_func method.

Other tftproot values are still checked if they represent a valid directory. It just implements a new feature that might come in handy for some use cases.