### PR TITLE
Fixed compatibility with Python 3.4 (issue #92)

### DIFF
--- a/tftpy/TftpPacketTypes.py
+++ b/tftpy/TftpPacketTypes.py
@@ -73,7 +73,7 @@ class TftpPacketWithOptions(object):
             if ord(buffer[i:i+1]) == 0:
                 log.debug("found a null at length %d", length)
                 if length > 0:
-                    fmt += b"%dsx" % length
+                    fmt +=  "{}sx".format(length).encode()
                     length = -1
                 else:
                     raise TftpException("Invalid options in buffer")
@@ -150,7 +150,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
             log.debug("    Option %s = %s", key, self.options[key])
 
         fmt = b"!H"
-        fmt += b"%dsx" % len(filename)
+        fmt += "{}sx".format(filename).encode()
         if mode == b"octet":
             fmt += b"5sx"
         else:
@@ -165,7 +165,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
                 if not isinstance(name, bytes):
                     name = name.encode('ascii')
                 options_list.append(name)
-                fmt += b"%dsx" % len(name)
+                fmt += "{}sx".format(name).encode()
                 # Populate the option value
                 value = self.options[key]
                 # Work with all strings.
@@ -174,7 +174,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
                 if not isinstance(value, bytes):
                     value = value.encode('ascii')
                 options_list.append(value)
-                fmt += b"%dsx" % len(value)
+                fmt += "{}sx".format(value).encode()
 
         log.debug("fmt is %s", fmt)
         log.debug("options_list is %s", options_list)
@@ -202,7 +202,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
             if ord(subbuf[i:i+1]) == 0:
                 nulls += 1
                 log.debug("found a null at length %d, now have %d", length, nulls)
-                fmt += b"%dsx" % length
+                fmt += "{}sx".format(length).encode()
                 length = -1
                 # At 2 nulls, we want to mark that position for decoding.
                 if nulls == 2:
@@ -297,7 +297,7 @@ class TftpPacketDAT(TftpPacket):
         data = self.data
         if not isinstance(self.data, bytes):
             data = self.data.encode('ascii')
-        fmt = b"!HH%ds" % len(data)
+        fmt = "!HH{}s".format(len(data)).encode()
         self.buffer = struct.pack(fmt,
                                   self.opcode,
                                   self.blocknumber,
@@ -399,7 +399,7 @@ class TftpPacketERR(TftpPacket):
     def encode(self):
         """Encode the DAT packet based on instance variables, populating
         self.buffer, returning self."""
-        fmt = b"!HH%dsx" % len(self.errmsgs[self.errorcode])
+        fmt = "!HH{}sx".format(len(self.errmsgs[self.errorcode])).encode()
         log.debug("encoding ERR packet with fmt %s", fmt)
         self.buffer = struct.pack(fmt,
                                   self.opcode,
@@ -420,7 +420,7 @@ class TftpPacketERR(TftpPacket):
                                                         self.buffer)
         else:
             log.debug("Good ERR packet > 4 bytes")
-            fmt = b"!HH%dsx" % (len(self.buffer) - 5)
+            fmt = "!HH{}sx".format((len(self.buffer) - 5)).encode()
             log.debug("Decoding ERR packet with fmt: %s", fmt)
             self.opcode, self.errorcode, self.errmsg = struct.unpack(fmt,
                                                                      self.buffer)
@@ -458,8 +458,8 @@ class TftpPacketOACK(TftpPacket, TftpPacketWithOptions):
                 value = value.encode('ascii')
             log.debug("looping on option key %s", key)
             log.debug("value is %s", value)
-            fmt += b"%dsx" % len(key)
-            fmt += b"%dsx" % len(value)
+            fmt += "!{}sx".format(len(key)).encode()
+            fmt += "!{}sx".format(len(value)).encode()
             options_list.append(key)
             options_list.append(value)
         self.buffer = struct.pack(fmt, self.opcode, *options_list)

--- a/tftpy/TftpPacketTypes.py
+++ b/tftpy/TftpPacketTypes.py
@@ -150,7 +150,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
             log.debug("    Option %s = %s", key, self.options[key])
 
         fmt = b"!H"
-        fmt += "{}sx".format(filename).encode()
+        fmt += "{}sx".format(len(filename)).encode()
         if mode == b"octet":
             fmt += b"5sx"
         else:
@@ -165,7 +165,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
                 if not isinstance(name, bytes):
                     name = name.encode('ascii')
                 options_list.append(name)
-                fmt += "{}sx".format(name).encode()
+                fmt += "{}sx".format(len(name)).encode()
                 # Populate the option value
                 value = self.options[key]
                 # Work with all strings.
@@ -174,7 +174,7 @@ class TftpPacketInitial(TftpPacket, TftpPacketWithOptions):
                 if not isinstance(value, bytes):
                     value = value.encode('ascii')
                 options_list.append(value)
-                fmt += "{}sx".format(value).encode()
+                fmt += "{}sx".format(len(value)).encode()
 
         log.debug("fmt is %s", fmt)
         log.debug("options_list is %s", options_list)


### PR DESCRIPTION
Unfortunately, 0.8.0 did not fix this exception being thrown on Python 3.4, which we have to use:
TypeError: unsupported operand type(s) for %: 'bytes' and 'int'
(referenced in #92)
(I tested 3.5-3.7 which work fine with % operator in byte strings, so it seems it may be only an issue with 3.4)

The fix turned out to be relatively simple - I moved from "%" operator in TftpPacketTypes.py wherever it was possible, to "new" .format() with strs, and encode to bytes at the very end.

I could not run unit tests as I'm developing on Windows and they use os.fork(), but I did run both the client and the server manually, uploading/downloading several files, errors included.

Before merging, feel free to check if it works on Python 2.7 (unless you plan to drop support), and possibly 3.7 or newer.