### PR TITLE
TftpServerState.serverInitial: prevent access to prefix-sharing siblings of tftproot

### DIFF
--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -279,7 +279,7 @@ class TftpServerState(TftpState):
         # root directory
         self.full_path = os.path.abspath(full_path)
         log.debug("full_path is %s", full_path)
-        if self.full_path.startswith(self.context.root):
+        if self.full_path.startswith(os.path.normpath(self.context.root) + "/"):
             log.info("requested file is in the server root - good")
         else:
             log.warning("requested file is not within the server root - bad")


### PR DESCRIPTION
Ok, I couldn't take it any longer. Here's the fix for #110.

Along with it I fleshed out the tests around permitted and disallowed request paths so that we have examples of absolute and relative requests for each. I really needed to go the extra step here and create a dummy populated root directory. Simply using files that happened to be hanging around the source tree would be too liable to accidental breakage from coincidental moves or renames. And such breakages would likely be silent because pretty much every failure just raises a `TftpException`. And a test asserting a `TftpException` is raised doesn't know/care whether it's because of a permissions failure or a "file not found" failure.