### PR TITLE
Fix #109: reading binary data from sys.stdin

### DIFF
--- a/tftpy/TftpContexts.py
+++ b/tftpy/TftpContexts.py
@@ -15,6 +15,7 @@ from .TftpShared import *
 from .TftpPacketTypes import *
 from .TftpPacketFactory import TftpPacketFactory
 from .TftpStates import *
+from . import compat
 import socket
 import time
 import sys
@@ -281,7 +282,7 @@ class TftpContextClientUpload(TftpContext):
         if hasattr(input, 'read'):
             self.fileobj = input
         elif input == '-':
-            self.fileobj = sys.stdin
+            self.fileobj = compat.binary_stdin()
         else:
             self.fileobj = open(input, "rb")
 

--- a/tftpy/compat.py
+++ b/tftpy/compat.py
@@ -1,0 +1,15 @@
+import sys
+
+def binary_stdin():
+    """
+    Get a file object for reading binary bytes from stdin instead of text.
+    Compatible with Py2/3, POSIX & win32.
+    Credits: https://stackoverflow.com/a/38939320/531179 (CC BY-SA 3.0)
+    """
+    if hasattr(sys.stdin, 'buffer'): # Py3+
+        return sys.stdin.buffer
+    else:
+        if sys.platform == 'win32':
+            import os, msvcrt
+            msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
+        return sys.stdin


### PR DESCRIPTION
This fixes #109, `UnicodeDecodeError`/`UnicodeEncodeError` from reading arbitrary binary data from `sys.stdin` with a usage like this:

    tftpy_client -H localhost -u remote_name.txt -i- < README

@wlq6037 please review & merge. 