### PR TITLE
Add the ability to configure the number of retransmission attempts after encountering a timeout

### DIFF
--- a/tftpy/TftpClient.py
+++ b/tftpy/TftpClient.py
@@ -32,7 +32,7 @@ class TftpClient(TftpSession):
             if size < MIN_BLKSIZE or size > MAX_BLKSIZE:
                 raise TftpException("Invalid blksize: %d" % size)
 
-    def download(self, filename, output, packethook=None, timeout=SOCK_TIMEOUT):
+    def download(self, filename, output, packethook=None, timeout=SOCK_TIMEOUT, retries=DEF_TIMEOUT_RETRIES):
         """This method initiates a tftp download from the configured remote
         host, requesting the filename passed. It writes the file to output,
         which can be a file-like object or a path to a local file. If a
@@ -41,6 +41,9 @@ class TftpClient(TftpSession):
         form of a TftpPacketDAT object. The timeout parameter may be used to
         override the default SOCK_TIMEOUT setting, which is the amount of time
         that the client will wait for a receive packet to arrive.
+        The retires paramater may be used to override the default DEF_TIMEOUT_RETRIES
+        settings, which is the amount of retransmission attemtpts the client will initiate
+        after encountering a timeout.
 
         Note: If output is a hyphen, stdout is used."""
         # We're downloading.
@@ -54,7 +57,8 @@ class TftpClient(TftpSession):
                                                  self.options,
                                                  packethook,
                                                  timeout,
-                                                 localip = self.localip)
+                                                 retries=retries,
+                                                 localip=self.localip)
         self.context.start()
         # Download happens here
         self.context.end()
@@ -71,7 +75,7 @@ class TftpClient(TftpSession):
         log.info("%.2f bytes in resent data" % metrics.resent_bytes)
         log.info("Received %d duplicate packets" % metrics.dupcount)
 
-    def upload(self, filename, input, packethook=None, timeout=SOCK_TIMEOUT):
+    def upload(self, filename, input, packethook=None, timeout=SOCK_TIMEOUT, retries=DEF_TIMEOUT_RETRIES):
         """This method initiates a tftp upload to the configured remote host,
         uploading the filename passed. It reads the file from input, which
         can be a file-like object or a path to a local file. If a packethook
@@ -80,6 +84,9 @@ class TftpClient(TftpSession):
         TftpPacketDAT object. The timeout parameter may be used to override
         the default SOCK_TIMEOUT setting, which is the amount of time that
         the client will wait for a DAT packet to be ACKd by the server.
+        The retires paramater may be used to override the default DEF_TIMEOUT_RETRIES
+        settings, which is the amount of retransmission attemtpts the client will initiate
+        after encountering a timeout.
 
         Note: If input is a hyphen, stdin is used."""
         self.context = TftpContextClientUpload(self.host,
@@ -89,7 +96,8 @@ class TftpClient(TftpSession):
                                                self.options,
                                                packethook,
                                                timeout,
-                                               localip = self.localip)
+                                               retries=retries,
+                                               localip=self.localip)
         self.context.start()
         # Upload happens here
         self.context.end()

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -77,7 +77,7 @@ class TftpServer(TftpSession):
             raise TftpException("The tftproot does not exist.")
 
     def listen(self, listenip="", listenport=DEF_TFTP_PORT,
-               timeout=SOCK_TIMEOUT):
+               timeout=SOCK_TIMEOUT, retries=DEF_TIMEOUT_RETRIES):
         """Start a server listening on the supplied interface and port. This
         defaults to INADDR_ANY (all interfaces) and UDP port 69. You can also
         supply a different socket timeout value, if desired."""
@@ -165,7 +165,8 @@ class TftpServer(TftpSession):
                                                                timeout,
                                                                self.root,
                                                                self.dyn_file_func,
-                                                               self.upload_open)
+                                                               self.upload_open,
+                                                               retries=retries)
                         try:
                             self.sessions[key].start(buffer)
                         except TftpException as err:

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -210,7 +210,7 @@ class TftpServer(TftpSession):
                 except TftpTimeout as err:
                     log.error(str(err))
                     self.sessions[key].retry_count += 1
-                    if self.sessions[key].retry_count >= TIMEOUT_RETRIES:
+                    if self.sessions[key].retry_count >= self.sessions[key].retries:
                         log.debug("hit max retries on %s, giving up" %
                             self.sessions[key])
                         deletion_list.append(key)

--- a/tftpy/TftpShared.py
+++ b/tftpy/TftpShared.py
@@ -9,7 +9,7 @@ DEF_BLKSIZE = 512
 MAX_BLKSIZE = 65536
 SOCK_TIMEOUT = 5
 MAX_DUPS = 20
-TIMEOUT_RETRIES = 5
+DEF_TIMEOUT_RETRIES = 5
 DEF_TFTP_PORT = 69
 
 # A hook for deliberately introducing delay in testing.


### PR DESCRIPTION
Currently, the amount of retries is constant and defined as **5** in the [TftpShared.py](https://github.com/msoulier/tftpy/blob/master/tftpy/TftpShared.py) file. This branch adds the ability to configure the amount of retires.