### PR TITLE
Fix def serverInitial to support Windows

### DIFF
--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -279,7 +279,7 @@ class TftpServerState(TftpState):
         # root directory
         self.full_path = os.path.abspath(full_path)
         log.debug("full_path is %s", full_path)
-        if self.full_path.startswith(os.path.normpath(self.context.root) + "/"):
+        if self.full_path.startswith(os.path.normpath(self.context.root) + os.sep):
             log.info("requested file is in the server root - good")
         else:
             log.warning("requested file is not within the server root - bad")


### PR DESCRIPTION
There are multiple places where hard-coded forward-slashes occur that can be replaced by `os.sep`.
This fixes just one showstopper.