### PR TITLE
run pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 ---
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
   - repo: https://github.com/python/black
     rev: 21.6b0
     hooks:
@@ -36,11 +41,6 @@ repos:
   #   rev: 3.9.2
   #   hooks:
   #     - id: flake8
-  # - repo: https://github.com/asottile/pyupgrade
-  # rev: v2.29.0
-  # hooks:
-  #   - id: pyupgrade
-  #     args: [ --py36-plus ]
   - repo: https://github.com/pycqa/isort
     rev: 5.9.1
     hooks:

--- a/bin/tftpy_client.py
+++ b/bin/tftpy_client.py
@@ -107,7 +107,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    class Progress(object):
+    class Progress:
         def __init__(self, out):
             self.progress = 0
             self.out = out

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 #
 # TFTPy documentation build configuration file, created by
 # sphinx-quickstart on Sun Jul 11 18:48:32 2010.
@@ -41,8 +40,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"TFTPy"
-copyright = u"2010, Michael P. Soulier"
+project = "TFTPy"
+copyright = "2010, Michael P. Soulier"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -176,7 +175,7 @@ htmlhelp_basename = "TFTPydoc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "TFTPy.tex", u"TFTPy Documentation", u"Michael P. Soulier", "manual"),
+    ("index", "TFTPy.tex", "TFTPy Documentation", "Michael P. Soulier", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
 # vim: ts=4 sw=4 et ai:
 import os
 

--- a/t/test.py
+++ b/t/test.py
@@ -267,7 +267,7 @@ class TestTftpyState(unittest.TestCase):
         self.customUploadHelper(lambda p: open(p, "wb"))
 
     def testClientServerUploadCustomOpenForbids(self):
-        with self.assertRaisesRegexp(tftpy.TftpException, "Access violation"):
+        with self.assertRaisesRegex(tftpy.TftpException, "Access violation"):
             self.customUploadHelper(lambda p: None)
 
     def testClientServerUploadTsize(self):

--- a/tftpy/TftpClient.py
+++ b/tftpy/TftpClient.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module implements the TFTP Client functionality. Instantiate an
 instance of the client, and then use its upload or download method. Logging is
 performed via a standard logging object set in TftpShared."""
@@ -57,9 +56,7 @@ class TftpClient(TftpSession):
         Note: If output is a hyphen, stdout is used."""
         # We're downloading.
         log.debug("Creating download context with the following params:")
-        log.debug(
-            "host = %s, port = %s, filename = %s" % (self.host, self.iport, filename)
-        )
+        log.debug(f"host = {self.host}, port = {self.iport}, filename = {filename}")
         log.debug(
             "options = %s, packethook = %s, timeout = %s"
             % (self.options, packethook, timeout)

--- a/tftpy/TftpContexts.py
+++ b/tftpy/TftpContexts.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module implements all contexts for state handling during uploads and
 downloads, the main interface to which being the TftpContext base class.
 
@@ -30,7 +29,7 @@ log = logging.getLogger("tftpy.TftpContext")
 ###############################################################################
 
 
-class TftpMetrics(object):
+class TftpMetrics:
     """A class representing metrics of the transfer."""
 
     def __init__(self):
@@ -79,7 +78,7 @@ class TftpMetrics(object):
 ###############################################################################
 
 
-class TftpContext(object):
+class TftpContext:
     """The base class of the contexts."""
 
     def __init__(self, host, port, timeout, retries=DEF_TIMEOUT_RETRIES, localip=""):
@@ -243,7 +242,7 @@ class TftpContextServer(TftpContext):
         self.upload_open = upload_open
 
     def __str__(self):
-        return "%s:%s %s" % (self.host, self.port, self.state)
+        return f"{self.host}:{self.port} {self.state}"
 
     def start(self, buffer):
         """
@@ -309,7 +308,7 @@ class TftpContextClientUpload(TftpContext):
         )
 
     def __str__(self):
-        return "%s:%s %s" % (self.host, self.port, self.state)
+        return f"{self.host}:{self.port} {self.state}"
 
     def start(self):
         log.info("Sending tftp upload request to %s" % self.host)
@@ -395,7 +394,7 @@ class TftpContextClientDownload(TftpContext):
         )
 
     def __str__(self):
-        return "%s:%s %s" % (self.host, self.port, self.state)
+        return f"{self.host}:{self.port} {self.state}"
 
     def start(self):
         """Initiate the download."""

--- a/tftpy/TftpPacketFactory.py
+++ b/tftpy/TftpPacketFactory.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module implements the TftpPacketFactory class, which can take a binary
 buffer, and return the appropriate TftpPacket object to represent it, via the
 parse() method."""
@@ -13,7 +12,7 @@ from .TftpShared import *
 log = logging.getLogger("tftpy.TftpPacketFactory")
 
 
-class TftpPacketFactory(object):
+class TftpPacketFactory:
     """This class generates TftpPacket objects. It is responsible for parsing
     raw buffers off of the wire and returning objects representing them, via
     the parse() method."""
@@ -33,7 +32,7 @@ class TftpPacketFactory(object):
         corresponding TftpPacket object. The buffer is the raw bytes off of
         the network."""
         log.debug("parsing a %d byte packet" % len(buffer))
-        (opcode,) = struct.unpack(str("!H"), buffer[:2])
+        (opcode,) = struct.unpack("!H", buffer[:2])
         log.debug("opcode is %d" % opcode)
         packet = self.__create(opcode)
         packet.buffer = buffer

--- a/tftpy/TftpPacketTypes.py
+++ b/tftpy/TftpPacketTypes.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module implements the packet types of TFTP itself, and the
 corresponding encode and decode methods for them."""
 
@@ -13,7 +12,7 @@ from .TftpShared import *
 log = logging.getLogger("tftpy.TftpPacketTypes")
 
 
-class TftpSession(object):
+class TftpSession:
     """This class is the base class for the tftp client and server. Any shared
     code should be in this class."""
 
@@ -21,7 +20,7 @@ class TftpSession(object):
     pass
 
 
-class TftpPacketWithOptions(object):
+class TftpPacketWithOptions:
     """This class exists to permit some TftpPacket subclasses to share code
     regarding options handling. It does not inherit from TftpPacket, as the
     goal is just to share code here, and not cause diamond inheritance."""
@@ -100,7 +99,7 @@ class TftpPacketWithOptions(object):
         return options
 
 
-class TftpPacket(object):
+class TftpPacket:
     """This class is the parent class of all tftp packet classes. It is an
     abstract class, providing an interface, and should not be instantiated
     directly."""
@@ -318,7 +317,7 @@ class TftpPacketDAT(TftpPacket):
         easy method chaining."""
         # We know the first 2 bytes are the opcode. The second two are the
         # block number.
-        (self.blocknumber,) = struct.unpack(str("!H"), self.buffer[2:4])
+        (self.blocknumber,) = struct.unpack("!H", self.buffer[2:4])
         log.debug("decoding DAT packet, block number %d", self.blocknumber)
         log.debug("should be %d bytes in the packet total", len(self.buffer))
         # Everything else is data.
@@ -349,7 +348,7 @@ class TftpPacketACK(TftpPacket):
         log.debug(
             "encoding ACK: opcode = %d, block = %d", self.opcode, self.blocknumber
         )
-        self.buffer = struct.pack(str("!HH"), self.opcode, self.blocknumber)
+        self.buffer = struct.pack("!HH", self.opcode, self.blocknumber)
         return self
 
     def decode(self):
@@ -357,7 +356,7 @@ class TftpPacketACK(TftpPacket):
             log.debug("detected TFTP ACK but request is too large, will truncate")
             log.debug("buffer was: %s", repr(self.buffer))
             self.buffer = self.buffer[0:4]
-        self.opcode, self.blocknumber = struct.unpack(str("!HH"), self.buffer)
+        self.opcode, self.blocknumber = struct.unpack("!HH", self.buffer)
         log.debug(
             "decoded ACK packet: opcode = %d, block = %d", self.opcode, self.blocknumber
         )

--- a/tftpy/TftpServer.py
+++ b/tftpy/TftpServer.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module implements the TFTP Server functionality. Instantiate an
 instance of the server, and then run the listen() method to listen for client
 requests. Logging is performed via a standard logging object set in
@@ -59,7 +58,7 @@ class TftpServer(TftpSession):
         for name in "dyn_file_func", "upload_open":
             attr = getattr(self, name)
             if attr and not callable(attr):
-                raise TftpException("{} supplied, but it is not callable.".format(name))
+                raise TftpException(f"{name} supplied, but it is not callable.")
         if os.path.exists(self.root):
             log.debug("tftproot %s does exist", self.root)
             if not os.path.isdir(self.root):
@@ -93,13 +92,13 @@ class TftpServer(TftpSession):
         # listenip = listenip if listenip else '0.0.0.0'
         if not listenip:
             listenip = "0.0.0.0"
-        log.info("Server requested on ip %s, port %s" % (listenip, listenport))
+        log.info(f"Server requested on ip {listenip}, port {listenport}")
         try:
             # FIXME - sockets should be non-blocking
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             self.sock.bind((listenip, listenport))
             _, self.listenport = self.sock.getsockname()
-        except socket.error as err:
+        except OSError as err:
             # Reraise it for now.
             raise err
 
@@ -134,7 +133,7 @@ class TftpServer(TftpSession):
                 readyinput, readyoutput, readyspecial = select.select(
                     inputlist, [], [], timeout
                 )
-            except select.error as err:
+            except OSError as err:
                 if err[0] == EINTR:
                     # Interrupted system call
                     log.debug("Interrupted syscall, retrying")
@@ -161,7 +160,7 @@ class TftpServer(TftpSession):
 
                     # Forge a session key based on the client's IP and port,
                     # which should safely work through NAT.
-                    key = "%s:%s" % (raddress, rport)
+                    key = f"{raddress}:{rport}"
 
                     if key not in self.sessions:
                         log.debug(

--- a/tftpy/TftpShared.py
+++ b/tftpy/TftpShared.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module holds all objects shared by all other modules in tftpy."""
 
 
@@ -24,7 +23,7 @@ def tftpassert(condition, msg):
         raise TftpException(msg)
 
 
-class TftpErrors(object):
+class TftpErrors:
     """This class is a convenience for defining the common tftp error codes,
     and making them more readable in the code."""
 

--- a/tftpy/TftpStates.py
+++ b/tftpy/TftpStates.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """This module implements all state handling during uploads and downloads, the
 main interface to which being the TftpState base class.
 
@@ -24,7 +23,7 @@ log = logging.getLogger("tftpy.TftpStates")
 ###############################################################################
 
 
-class TftpState(object):
+class TftpState:
     """The base class for the states."""
 
     def __init__(self, context):
@@ -47,7 +46,7 @@ class TftpState(object):
                 # Set options to OACK options
                 self.context.options = pkt.options
                 for key in self.context.options:
-                    log.info("    %s = %s" % (key, self.context.options[key]))
+                    log.info(f"    {key} = {self.context.options[key]}")
             else:
                 log.error("Failed to negotiate options")
                 raise TftpException("Failed to negotiate options")
@@ -159,9 +158,7 @@ class TftpState(object):
 
     def resendLast(self):
         """Resend the last sent packet due to a timeout."""
-        log.warning(
-            "Resending packet %s on sessions %s" % (self.context.last_pkt, self)
-        )
+        log.warning(f"Resending packet {self.context.last_pkt} on sessions {self}")
         self.context.metrics.resent_bytes += len(self.context.last_pkt.buffer)
         self.context.metrics.add_dup(self.context.last_pkt)
         sendto_port = self.context.tidport
@@ -328,7 +325,7 @@ class TftpStateServerRecvRRQ(TftpServerState):
         else:
             log.warning("File not found: %s", path)
             self.sendError(TftpErrors.FileNotFound)
-            raise TftpException("File not found: {}".format(path))
+            raise TftpException(f"File not found: {path}")
 
         # Options negotiation.
         if sendoack and "tsize" in self.context.options:
@@ -622,7 +619,7 @@ class TftpStateSentRRQ(TftpState):
             if pkt.errorcode == TftpErrors.FileNotFound:
                 raise TftpFileNotFoundError("File not found")
             else:
-                raise TftpException("Received ERR from server: {}".format(pkt))
+                raise TftpException(f"Received ERR from server: {pkt}")
 
         else:
             self.sendError(TftpErrors.IllegalTftpOp)

--- a/tftpy/__init__.py
+++ b/tftpy/__init__.py
@@ -1,5 +1,4 @@
 # vim: ts=4 sw=4 et ai:
-# -*- coding: utf8 -*-
 """
 This library implements the tftp protocol, based on rfc 1350.
 http://www.faqs.org/rfcs/rfc1350.html


### PR DESCRIPTION
Running of the autoformatter[ `pyupgrade`](https://github.com/asottile/pyupgrade) with the `py36-plus` flag to move to modern python where applicable.
This is run before `black` as black may format the code differently based on the suggestions